### PR TITLE
Fix issue unmarshaling ethernet interfaces from SMD

### DIFF
--- a/pkg/clients/hsm/client.go
+++ b/pkg/clients/hsm/client.go
@@ -298,16 +298,16 @@ func (c *HSMClient) GetEthernetInterfaces(ctx context.Context) ([]HSMEthernetInt
 		return nil, fmt.Errorf("HSM returned status %d", resp.StatusCode)
 	}
 
-	var hsmResp HSMEthernetResponse
+	var hsmResp []HSMEthernetInterface
 	if err := json.NewDecoder(resp.Body).Decode(&hsmResp); err != nil {
 		return nil, fmt.Errorf("failed to decode HSM response: %w", err)
 	}
 
 	// Cache the result
-	c.cache.SetEthernet("all_ethernet", hsmResp.EthernetInterfaces)
+	c.cache.SetEthernet("all_ethernet", hsmResp)
 
-	c.logger.Printf("Retrieved %d ethernet interfaces from HSM", len(hsmResp.EthernetInterfaces))
-	return hsmResp.EthernetInterfaces, nil
+	c.logger.Printf("Retrieved %d ethernet interfaces from HSM", len(hsmResp))
+	return hsmResp, nil
 }
 
 // GetComponentByMAC finds a component by its MAC address


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

This PR fixes an issue with unmarshaling the `EthernetInterface`s int the cache synchronization with the the HSM (in this case SMD). It changes the type of the `hsmResp` variable in `pkg/clients/hsm/client.go` from `HSMEthernetResponse` to `[]HSMEthernetInterface` and its corresponding uses.

Fixes #(issue)

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
