### PR TITLE
Add profile query param

### DIFF
--- a/examples/boot_script_demo.go
+++ b/examples/boot_script_demo.go
@@ -17,13 +17,18 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 2 {
-		fmt.Fprintf(os.Stderr, "Usage: %s <node-identifier>\n", os.Args[0])
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <node-identifier> [profile]\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "  node-identifier can be XName, NID, or MAC address\n")
 		os.Exit(1)
 	}
 
 	identifier := os.Args[1]
+	
+	profile := ""
+	if len(os.Args) > 2 {
+		profile = os.Args[2]
+	}
 
 	// Create client
 	bootClient, err := client.NewClient("http://localhost:8080", &http.Client{Timeout: 30 * time.Second})
@@ -37,11 +42,13 @@ func main() {
 
 	// Generate boot script
 	ctx := context.Background()
-	script, err := controller.GenerateBootScript(ctx, identifier)
+	
+	script, err := controller.GenerateBootScript(ctx, identifier, profile)
 	if err != nil {
 		log.Fatalf("Failed to generate boot script: %v", err)
 	}
 
 	// Output the script
+	fmt.Printf("# Profile: %s\n", profile)
 	fmt.Print(script)
 }

--- a/pkg/controllers/bootscript/controller.go
+++ b/pkg/controllers/bootscript/controller.go
@@ -147,6 +147,11 @@ func (c *BootScriptController) resolveNode(ctx context.Context, identifier NodeI
 	return nil, fmt.Errorf("node not found for identifier %s", identifier.Value)
 }
 
+type configCandidate struct {
+    config *bootconfiguration.BootConfiguration
+    score  int
+}
+
 // findBootConfiguration finds the best matching configuration for a node
 func (c *BootScriptController) findBootConfiguration(ctx context.Context, node *node.Node, profile string) (*bootconfiguration.BootConfiguration, error) {
     // Get all boot configurations

--- a/pkg/controllers/bootscript/controller.go
+++ b/pkg/controllers/bootscript/controller.go
@@ -54,11 +54,11 @@ const (
 )
 
 // GenerateBootScript generates an iPXE boot script for a node
-func (c *BootScriptController) GenerateBootScript(ctx context.Context, identifier string) (string, error) {
+func (c *BootScriptController) GenerateBootScript(ctx context.Context, identifier string, profile string) (string, error) {
 	c.logger.Printf("Generating boot script for identifier: %s", identifier)
 
 	// Check cache first
-	cacheKey := c.generateCacheKey(identifier, "")
+	cacheKey := c.generateCacheKey(identifier, profile)
 	if cached, found := c.cache.Get(cacheKey); found {
 		c.logger.Printf("Cache hit for identifier: %s", identifier)
 		return cached, nil
@@ -72,7 +72,7 @@ func (c *BootScriptController) GenerateBootScript(ctx context.Context, identifie
 	}
 
 	// Find best matching configuration
-	config, err := c.findBootConfiguration(ctx, node)
+	config, err := c.findBootConfiguration(ctx, node, profile)
 	if err != nil {
 		c.logger.Printf("No configuration found for node %s: %v", node.Spec.XName, err)
 		// Return minimal script for nodes without configuration

--- a/pkg/controllers/bootscript/enhanced_controller.go
+++ b/pkg/controllers/bootscript/enhanced_controller.go
@@ -37,7 +37,7 @@ func (c *EnhancedBootScriptController) GenerateBootScriptWithHSM(ctx context.Con
 	c.logger.Printf("Generating boot script for identifier: %s (with HSM fallback)", identifier)
 
 	// First try the standard resolution
-	script, err := c.GenerateBootScript(ctx, identifier)
+	script, err := c.GenerateBootScript(ctx, identifier, "")
 	if err == nil {
 		return script, nil
 	}
@@ -55,7 +55,7 @@ func (c *EnhancedBootScriptController) GenerateBootScriptWithHSM(ctx context.Con
 	c.logger.Printf("HSM resolved node %s for identifier %s", node.Spec.XName, identifier)
 
 	// Now try to generate script with the HSM-resolved node
-	script, err = c.GenerateBootScript(ctx, node.Spec.XName)
+	script, err = c.GenerateBootScript(ctx, node.Spec.XName, "")
 	if err != nil {
 		c.logger.Printf("Failed to generate script for HSM-resolved node %s: %v", node.Spec.XName, err)
 		return c.generateMinimalScript(identifier), nil

--- a/pkg/controllers/bootscript/flexible_controller.go
+++ b/pkg/controllers/bootscript/flexible_controller.go
@@ -97,7 +97,7 @@ func (c *FlexibleBootScriptController) GenerateBootScriptWithFallback(ctx contex
 	c.logger.Printf("Generating boot script for identifier: %s (provider: %s)", identifier, c.providerType)
 
 	// First try the standard resolution
-	script, err := c.GenerateBootScript(ctx, identifier)
+	script, err := c.GenerateBootScript(ctx, identifier, "")
 	if err == nil {
 		return script, nil
 	}
@@ -121,7 +121,7 @@ func (c *FlexibleBootScriptController) GenerateBootScriptWithFallback(ctx contex
 	c.logger.Printf("%s provider resolved node %s for identifier %s", c.providerType, node.Spec.XName, identifier)
 
 	// Now try to generate script with the resolved node
-	script, err = c.GenerateBootScript(ctx, node.Spec.XName)
+	script, err = c.GenerateBootScript(ctx, node.Spec.XName, "")
 	if err != nil {
 		c.logger.Printf("Failed to generate script for %s-resolved node %s: %v", c.providerType, node.Spec.XName, err)
 		return c.generateMinimalScript(identifier), nil

--- a/pkg/handlers/legacy/handlers.go
+++ b/pkg/handlers/legacy/handlers.go
@@ -22,7 +22,7 @@ import (
 
 // BootController interface for boot script generation
 type BootController interface {
-    GenerateBootScript(ctx context.Context, identifier string, profile string) (string, error)
+	GenerateBootScript(ctx context.Context, identifier string, profile string) (string, error)
 }
 
 // LegacyHandler handles legacy BSS API requests
@@ -267,40 +267,40 @@ func (h *LegacyHandler) DeleteBootParameters(w http.ResponseWriter, r *http.Requ
 
 // GetBootScript handles GET /boot/v1/bootscript
 func (h *LegacyHandler) GetBootScript(w http.ResponseWriter, r *http.Request) {
-    ctx := r.Context()
+	ctx := r.Context()
 
-    // Parse query parameters for node identification
-    host := r.URL.Query().Get("host")
-    mac := r.URL.Query().Get("mac")
-    nid := r.URL.Query().Get("nid")
+	// Parse query parameters for node identification
+	host := r.URL.Query().Get("host")
+	mac := r.URL.Query().Get("mac")
+	nid := r.URL.Query().Get("nid")
 
-    // Create boot script request
-    req := BootScriptRequest{
-        Host:   host,
-        Mac:    mac,
-        Nid:    nid,
-        Format: r.URL.Query().Get("format"), // defaults to "ipxe"
-    }
+	// Create boot script request
+	req := BootScriptRequest{
+		Host:   host,
+		Mac:    mac,
+		Nid:    nid,
+		Format: r.URL.Query().Get("format"), // defaults to "ipxe"
+	}
 
-    // Extract the node identifier
-    identifier := ExtractNodeIdentifier(req)
-    if identifier == "" {
-        h.writeError(w, http.StatusBadRequest, "Missing node identifier", "At least one node identifier (host, mac, or nid) must be provided")
-        return
-    }
+	// Extract the node identifier
+	identifier := ExtractNodeIdentifier(req)
+	if identifier == "" {
+		h.writeError(w, http.StatusBadRequest, "Missing node identifier", "At least one node identifier (host, mac, or nid) must be provided")
+		return
+	}
 
-    profile := r.URL.Query().Get("profile")
+	profile := r.URL.Query().Get("profile")
 
-    script, err := h.controller.GenerateBootScript(ctx, identifier, profile)
-    if err != nil {
-        h.writeError(w, http.StatusInternalServerError, "Failed to generate boot script", err.Error())
-        return
-    }
+	script, err := h.controller.GenerateBootScript(ctx, identifier, profile)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, "Failed to generate boot script", err.Error())
+		return
+	}
 
-    // Return the script as plain text (iPXE format)
-    w.Header().Set("Content-Type", "text/plain")
-    w.WriteHeader(http.StatusOK)
-    w.Write([]byte(script)) //nolint:errcheck
+	// Return the script as plain text (iPXE format)
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(script)) //nolint:errcheck
 }
 
 // GetServiceStatus handles GET /boot/v1/service/status

--- a/pkg/handlers/legacy/handlers.go
+++ b/pkg/handlers/legacy/handlers.go
@@ -22,7 +22,7 @@ import (
 
 // BootController interface for boot script generation
 type BootController interface {
-	GenerateBootScript(ctx context.Context, identifier string) (string, error)
+	GenerateBootScript(ctx context.Context, identifier string) (string, error, profile string)
 }
 
 // LegacyHandler handles legacy BSS API requests
@@ -289,8 +289,10 @@ func (h *LegacyHandler) GetBootScript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	profile := req.URL.Query().Get("profile")
+
 	// Generate the boot script using our boot logic
-	script, err := h.controller.GenerateBootScript(ctx, identifier)
+	script, err := h.controller.GenerateBootScript(ctx, identifier, profile)
 	if err != nil {
 		h.writeError(w, http.StatusInternalServerError, "Failed to generate boot script", err.Error())
 		return

--- a/pkg/resources/bootconfiguration/bootconfiguration.go
+++ b/pkg/resources/bootconfiguration/bootconfiguration.go
@@ -28,6 +28,8 @@ type BootConfigurationSpec struct { // nolint:revive
 	NIDs   []int32  `json:"nids,omitempty"`
 	Groups []string `json:"groups,omitempty"` // Support for inventory service groups
 
+	Profile string `json:"profile,omitempty"`
+
 	// Boot configuration (kernel required)
 	Kernel string `json:"kernel"`
 	Initrd string `json:"initrd,omitempty"`


### PR DESCRIPTION
This PR implements phase 2 of the plan outlined in https://github.com/OpenCHAMI/roadmap/issues/121 by adding a profile query param.

To test, first a "Default" configuration that points to the stable kernel is created.

```bash
$ go run ./cmd/client/main.go bootconfiguration create --spec '{"kernel":"http://boot.server/vmlinuz-stable", "params":"console=tty0", "hosts":["x1000c0s0b0n0"]}'
{
  "apiVersion": "v1",
  "kind": "BootConfiguration",
  "schemaVersion": "v1",
  "metadata": {
    "name": "",
    "uid": "boo-248b33d3",
    "createdAt": "2026-02-02T10:42:46.100635-08:00",
    "updatedAt": "2026-02-02T10:42:46.100635-08:00"
  },
  "spec": {
    "hosts": [
      "x1000c0s0b0n0"
    ],
    "kernel": "http://boot.server/vmlinuz-stable",
    "params": "console=tty0"
  },
  "status": {}
}
```

Next, a "Staging" configuration is added that points to the beta kernel, tagged with `profile: staging`.

```bash
$ go run ./cmd/client/main.go bootconfiguration create --spec '{"kernel":"http://boot.server/vmlinuz-beta", "params":"console=tty0", "hosts":["x1000c0s0b0n0"], "profile":"staging"}'
{
  "apiVersion": "v1",
  "kind": "BootConfiguration",
  "schemaVersion": "v1",
  "metadata": {
    "name": "",
    "uid": "boo-5034631c",
    "createdAt": "2026-02-02T10:42:52.153509-08:00",
    "updatedAt": "2026-02-02T10:42:52.153509-08:00"
  },
  "spec": {
    "hosts": [
      "x1000c0s0b0n0"
    ],
    "profile": "staging",
    "kernel": "http://boot.server/vmlinuz-beta",
    "params": "console=tty0"
  },
  "status": {}
}
```

Then, the node is registered so the Boot Service can resolve the XName.

```bash
$ go run ./cmd/client/main.go node create --spec '{"xname":"x1000c0s0b0n0", "nid":1000, "bootMac":"00:11:22:33:44:55"}'
{
  "apiVersion": "v1",
  "kind": "Node",
  "schemaVersion": "v1",
  "metadata": {
    "name": "",
    "uid": "nod-c0b9171c",
    "createdAt": "2026-02-02T10:43:35.000814-08:00",
    "updatedAt": "2026-02-02T10:43:35.000814-08:00"
  },
  "spec": {
    "xname": "x1000c0s0b0n0",
    "nid": 1000,
    "bootMac": "00:11:22:33:44:55"
  },
  "status": {}
}
```

### Test A: Default Boot (No Profile)
Boot script requested without specifying a profile. The service correctly serves the stable kernel.

```bash
$ curl "http://localhost:8080/boot/v1/bootscript?host=x1000c0s0b0n0"
#!ipxe
# iPXE Boot Script
# Generated by OpenCHAMI Boot Service
# Node: x1000c0s0b0n0 (NID: 1000)
# Configuration:
# Role:

echo Starting boot for x1000c0s0b0n0
echo Using configuration:
echo Role:

# Configure network interface
dhcp

# Set boot parameters
set kernel http://boot.server/vmlinuz-stable
set params console=tty0

# Download and verify kernel
echo Downloading kernel: vmlinuz-stable
kernel ${kernel} ${params}

# Boot the system
echo Booting x1000c0s0b0n0...
boot
```

### Test B: Staging Boot (Sticky Profile)
Boot script requested with `?profile=staging`. The service correctly identifies the override and serves the beta kernel.

```bash
$ curl "http://localhost:8080/boot/v1/bootscript?host=x1000c0s0b0n0&profile=staging"
#!ipxe
# iPXE Boot Script
# Generated by OpenCHAMI Boot Service
# Node: x1000c0s0b0n0 (NID: 1000)
# Configuration:
# Role:

echo Starting boot for x1000c0s0b0n0
echo Using configuration:
echo Role:

# Configure network interface
dhcp

# Set boot parameters
set kernel http://boot.server/vmlinuz-beta
set params console=tty0

# Download and verify kernel
echo Downloading kernel: vmlinuz-beta
kernel ${kernel} ${params}

# Boot the system
echo Booting x1000c0s0b0n0...
boot
```