### PR TITLE
fix: add openapi API routes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -299,6 +299,10 @@ func runServe(cmd *cobra.Command, args []string) error { //nolint:revive
 		w.Write([]byte(`{"status":"ok","service":"boot-service"}`)) //nolint:errcheck
 	})
 
+	// Register OpenAPI endpoints
+	r.Get("/openapi.json", ServeOpenAPISpec)
+	r.Get("/docs", ServeSwaggerUI)
+
 	// Setup metrics endpoint if enabled (before other routes)
 	if config.EnableMetrics {
 		// Add metrics to main router


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

Re-add missing OpenAPI endpoints:

- `/openapi.json`: OpenAPI spec in JSON format
- `/docs`: OpenAPI UI

Fabrica does not regenerate main.go, so these must be added manually.

To test:

1. `make build`
2. `go run ./cmd/server/ serve`
3. `curl localhost:8080/openapi.json`
4. `curl localhost:8080/docs`

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
