### PR TITLE
feat(bootscript): add BOOTIF param from requesting MAC (#17)

### DIFF
--- a/pkg/controllers/bootscript/controller_test.go
+++ b/pkg/controllers/bootscript/controller_test.go
@@ -82,7 +82,7 @@ func TestIPXETemplates(t *testing.T) {
 		"x0c0s0b0n0",
 		"vmlinuz",
 		"initramfs",
-		"console=tty0 console=ttyS0,115200",
+		"console=tty0 console=ttyS0,115200 BOOTIF=01-a4-bf-01-00-00-01",
 		"dhcp",
 		"boot",
 	}
@@ -143,7 +143,6 @@ func TestTemplateVariablePreparation(t *testing.T) {
 
 	vars := controller.prepareTemplateVars(config, testNode)
 
-	// Test node variables
 	if vars["XName"] != "x0c0s1b0n0" {
 		t.Errorf("Expected XName x0c0s1b0n0, got %v", vars["XName"])
 	}
@@ -156,19 +155,50 @@ func TestTemplateVariablePreparation(t *testing.T) {
 	if vars["Groups"] != "login,management" {
 		t.Errorf("Expected Groups login,management, got %v", vars["Groups"])
 	}
-
-	// Test config variables
 	if vars["Kernel"] != "http://files.example.com/vmlinuz-5.4.0" {
 		t.Errorf("Expected Kernel URL, got %v", vars["Kernel"])
 	}
-
-	// Test derived variables
 	if vars["KernelFilename"] != "vmlinuz-5.4.0" {
 		t.Errorf("Expected KernelFilename vmlinuz-5.4.0, got %v", vars["KernelFilename"])
 	}
 	if vars["InitrdFilename"] != "initramfs-5.4.0" {
 		t.Errorf("Expected InitrdFilename initramfs-5.4.0, got %v", vars["InitrdFilename"])
 	}
+	if vars["Params"] != "console=ttyS0,115200 BOOTIF=01-aa-bb-cc-dd-ee-ff" {
+		t.Errorf("Expected Params with BOOTIF, got %v", vars["Params"])
+	}
+
+	t.Run("EmptyParams", func(t *testing.T) {
+		cfg := &apiv1.BootConfiguration{
+			Spec: apiv1.BootConfigurationSpec{Kernel: config.Spec.Kernel, Params: ""},
+		}
+		v := controller.prepareTemplateVars(cfg, testNode)
+		if v["Params"] != "BOOTIF=01-aa-bb-cc-dd-ee-ff" {
+			t.Errorf("Expected BOOTIF only, got %v", v["Params"])
+		}
+	})
+
+	t.Run("AlreadyHasBOOTIF", func(t *testing.T) {
+		cfg := &apiv1.BootConfiguration{
+			Spec: apiv1.BootConfigurationSpec{
+				Kernel: config.Spec.Kernel,
+				Params: "console=ttyS0,115200 BOOTIF=01-11-22-33-44-55-66",
+			},
+		}
+		v := controller.prepareTemplateVars(cfg, testNode)
+		if v["Params"] != "console=ttyS0,115200 BOOTIF=01-11-22-33-44-55-66" {
+			t.Errorf("Expected unchanged Params, got %v", v["Params"])
+		}
+	})
+
+	t.Run("EmptyBootMAC", func(t *testing.T) {
+		noMacNode := &apiv1.Node{Spec: apiv1.NodeSpec{XName: "x0c0s1b0n0", BootMAC: ""}}
+		v := controller.prepareTemplateVars(config, noMacNode)
+		if v["Params"] != "console=ttyS0,115200" {
+			t.Errorf("Expected unchanged Params when no MAC, got %v", v["Params"])
+		}
+	})
+
 }
 
 // createTestController creates a minimal controller for testing

--- a/pkg/controllers/bootscript/ipxe.go
+++ b/pkg/controllers/bootscript/ipxe.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"net"
 	"strings"
 
 	apiv1 "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
@@ -50,7 +51,7 @@ func (c *BootScriptController) prepareTemplateVars(config *apiv1.BootConfigurati
 		// Boot configuration
 		"Kernel":   config.Spec.Kernel,
 		"Initrd":   config.Spec.Initrd,
-		"Params":   config.Spec.Params,
+		"Params":   buildParams(config.Spec.Params, node.Spec.BootMAC),
 		"Priority": config.Spec.Priority,
 
 		// Configuration metadata
@@ -73,6 +74,33 @@ func extractFilename(urlOrPath string) string {
 
 	parts := strings.Split(urlOrPath, "/")
 	return parts[len(parts)-1]
+}
+
+// formatBootif formats a MAC address as a BOOTIF kernel parameter value (e.g. "01-aa-bb-cc-dd-ee-ff").
+func formatBootif(mac string) string {
+	hwAddr, err := net.ParseMAC(mac)
+	if err != nil {
+		return ""
+	}
+	parts := make([]string, len(hwAddr))
+	for i, b := range hwAddr {
+		parts[i] = fmt.Sprintf("%02x", b)
+	}
+	return "01-" + strings.Join(parts, "-")
+}
+
+func buildParams(params, mac string) string {
+	if mac == "" || strings.Contains(params, "BOOTIF=") {
+		return params
+	}
+	bootif := formatBootif(mac)
+	if bootif == "" {
+		return params
+	}
+	if params != "" {
+		return params + " BOOTIF=" + bootif
+	}
+	return "BOOTIF=" + bootif
 }
 
 // DefaultIPXETemplate is the standard template for generating iPXE scripts


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

## Description

### Summary
This change updates the boot-service boot script generation to automatically append a `BOOTIF=01-<mac>` kernel parameter derived from the requesting node’s MAC address.

### Motivation
Linux can reset or reconfigure network interfaces during boot, which may cause a network-booted node to lose connectivity. Adding `BOOTIF` ensures the kernel keeps using the correct booting interface.

### Changes
- Added MAC-to-BOOTIF formatting logic.
- Appended `BOOTIF` to generated kernel parameters when it is not already present.
- Added tests covering normal, empty, and pre-existing `BOOTIF` cases.

## Testing
- `gofmt -w .`
- `go vet ./...`
- `go test ./...`


Fixes #17

### Type of Change

- [x] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---
