### PR TITLE
refactor(config): remove legacy TokenSmith scope inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Changes remain under `Unreleased` until they ship in the next tagged release.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the legacy `tokensmith_scopes`/`TOKENSMITH_SCOPES`/`--tokensmith-scopes`
+  compatibility inputs.
+  - Use `tokensmith_bootstrap_policy_scopes_hint`/`TOKENSMITH_BOOTSTRAP_POLICY_SCOPES_HINT`/`--tokensmith-bootstrap-policy-scopes-hint`
+    instead.
+
 ## [v0.3.0] - 2026-07-22
 
 ### Added

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,7 +58,6 @@ type Config struct {
 	TokenSmithBootstrapToken            string `mapstructure:"tokensmith_bootstrap_token"`
 	TokenSmithTargetService             string `mapstructure:"tokensmith_target_service"`
 	TokenSmithBootstrapPolicyScopesHint string `mapstructure:"tokensmith_bootstrap_policy_scopes_hint"`
-	TokenSmithScopesLegacy              string `mapstructure:"tokensmith_scopes"`
 	TokenSmithRefreshSkewSec            int    `mapstructure:"tokensmith_refresh_skew_sec"`
 	JWKSEndpoint                        string `mapstructure:"jwks_endpoint"`
 
@@ -86,7 +85,6 @@ func DefaultConfig() *Config {
 		TokenSmithBootstrapToken:            "",
 		TokenSmithTargetService:             "hsm",
 		TokenSmithBootstrapPolicyScopesHint: "",
-		TokenSmithScopesLegacy:              "",
 		TokenSmithRefreshSkewSec:            120,
 		JWKSEndpoint:                        "",
 		HSMURL:                              "",
@@ -150,7 +148,6 @@ func init() {
 	serveCmd.Flags().String("tokensmith-bootstrap-token", "", "Bootstrap token used to exchange HSM service tokens")
 	serveCmd.Flags().String("tokensmith-target-service", "hsm", "Target service audience for HSM service token exchange")
 	serveCmd.Flags().String("tokensmith-bootstrap-policy-scopes-hint", "", "Comma-separated scope hint from bootstrap token policy used for diagnostics only")
-	serveCmd.Flags().String("tokensmith-scopes", "", "Deprecated alias for --tokensmith-bootstrap-policy-scopes-hint")
 	serveCmd.Flags().Int("tokensmith-refresh-skew-sec", 120, "Refresh service tokens when this many seconds remain before expiry")
 	serveCmd.Flags().String("jwks-endpoint", "", "JWKS endpoint for JWT validation")
 
@@ -217,7 +214,6 @@ func main() {
 	viper.BindEnv("tokensmith_bootstrap_token", "TOKENSMITH_BOOTSTRAP_TOKEN")                           //nolint:errcheck
 	viper.BindEnv("tokensmith_target_service", "TOKENSMITH_TARGET_SERVICE")                             //nolint:errcheck
 	viper.BindEnv("tokensmith_bootstrap_policy_scopes_hint", "TOKENSMITH_BOOTSTRAP_POLICY_SCOPES_HINT") //nolint:errcheck
-	viper.BindEnv("tokensmith_scopes", "TOKENSMITH_SCOPES")                                             //nolint:errcheck
 	viper.BindEnv("tokensmith_refresh_skew_sec", "TOKENSMITH_REFRESH_SKEW_SEC")                         //nolint:errcheck
 
 	if err := rootCmd.Execute(); err != nil {
@@ -381,15 +377,6 @@ func validateConfig(config Config) error {
 	return nil
 }
 
-func tokenSmithScopeHintCSV(config Config) string {
-	if strings.TrimSpace(config.TokenSmithBootstrapPolicyScopesHint) != "" {
-		return config.TokenSmithBootstrapPolicyScopesHint
-	}
-
-	// Backward compatibility for legacy key/env/flag names.
-	return config.TokenSmithScopesLegacy
-}
-
 func parseScopeHintCSV(raw string) []string {
 	if strings.TrimSpace(raw) == "" {
 		return nil
@@ -435,7 +422,7 @@ func initializeHSMServiceTokenManager(ctx context.Context, config Config, hsmLog
 	tokenConfig.TokenSmithURL = config.TokenSmithURL
 	tokenConfig.BootstrapToken = bootstrapToken
 	tokenConfig.TargetService = strings.TrimSpace(config.TokenSmithTargetService)
-	tokenConfig.Scopes = parseScopeHintCSV(tokenSmithScopeHintCSV(config))
+	tokenConfig.Scopes = parseScopeHintCSV(config.TokenSmithBootstrapPolicyScopesHint)
 	tokenConfig.RefreshBefore = time.Duration(config.TokenSmithRefreshSkewSec) * time.Second
 
 	tokenEndpoint := strings.TrimRight(tokenConfig.TokenSmithURL, "/") + "/oauth/token"

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -33,6 +33,7 @@ func TestBindFlagsWithUnderscoreKeys_ConfigValuesBeatUnchangedFlagDefaults(t *te
 	flags.Bool("enable-legacy-api", true, "Enable legacy BSS API compatibility")
 	flags.String("tokensmith-url", "", "TokenSmith service URL for authentication")
 	flags.String("tokensmith-target-service", "hsm", "Target service audience for HSM service token exchange")
+	flags.String("tokensmith-bootstrap-policy-scopes-hint", "", "Bootstrap policy scope hint for diagnostics")
 	flags.String("hsm-url", "", "Hardware State Manager service URL")
 	flags.Bool("hsm-sync-enabled", true, "Enable background sync with HSM")
 
@@ -46,6 +47,7 @@ func TestBindFlagsWithUnderscoreKeys_ConfigValuesBeatUnchangedFlagDefaults(t *te
 enable_auth: true
 tokensmith_url: http://tokensmith:8080
 tokensmith_target_service: smd
+tokensmith_bootstrap_policy_scopes_hint: hsm:read,hsm:write
 hsm_url: http://smd:27779
 hsm_sync_enabled: true
 enable_legacy_api: true
@@ -69,6 +71,9 @@ enable_metrics: false
 	if config.TokenSmithTargetService != "smd" {
 		t.Fatalf("expected tokensmith_target_service from config, got %q", config.TokenSmithTargetService)
 	}
+	if config.TokenSmithBootstrapPolicyScopesHint != "hsm:read,hsm:write" {
+		t.Fatalf("expected tokensmith_bootstrap_policy_scopes_hint from config, got %q", config.TokenSmithBootstrapPolicyScopesHint)
+	}
 	if config.HSMURL != "http://smd:27779" {
 		t.Fatalf("expected hsm_url config value to override unchanged --hsm-url default, got %q", config.HSMURL)
 	}
@@ -80,6 +85,15 @@ enable_metrics: false
 	}
 	if config.EnableMetrics {
 		t.Fatal("expected enable_metrics to remain false")
+	}
+}
+
+func TestServeCommandRegistersOnlyCanonicalTokenSmithScopeHintFlag(t *testing.T) {
+	if serveCmd.Flags().Lookup("tokensmith-bootstrap-policy-scopes-hint") == nil {
+		t.Fatal("expected canonical TokenSmith scope hint flag to be registered")
+	}
+	if serveCmd.Flags().Lookup("tokensmith-scopes") != nil {
+		t.Fatal("legacy TokenSmith scopes flag must not be registered")
 	}
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,9 +74,6 @@ tokensmith_target_service: "hsm"
 # service tokens.
 tokensmith_bootstrap_policy_scopes_hint: ""
 
-# Deprecated legacy alias still accepted by current code.
-# tokensmith_scopes: "hsm:read"
-
 # Refresh skew in seconds applied before service tokens are considered stale.
 tokensmith_refresh_skew_sec: 120
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -92,10 +92,6 @@ Standardized environment variables:
 - `TOKENSMITH_BOOTSTRAP_POLICY_SCOPES_HINT`: optional scope hint used in diagnostics, for example `hsm:read`
 - `TOKENSMITH_REFRESH_SKEW_SEC`: refresh skew in seconds before a cached service token is treated as stale
 
-Deprecated compatibility environment variable:
-
-- `TOKENSMITH_SCOPES`
-
 ## JWKS and Static-Key Notes
 
 JWKS and static RSA key support are implemented in `pkg/auth`, but they are not

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -101,12 +101,6 @@ Environment fallback:
 export TOKENSMITH_BOOTSTRAP_TOKEN="<bootstrap-jwt>"
 ```
 
-Deprecated compatibility input still accepted:
-
-```yaml
-# tokensmith_scopes: "hsm:read"
-```
-
 ## Current Auth Behavior
 
 `enable_auth` does **not** currently attach the `pkg/auth` request middleware to


### PR DESCRIPTION
### Description

Remove support for the deprecated `tokensmith_scopes` configuration key, `TOKENSMITH_SCOPES` environment variable, and `--tokensmith-scopes` CLI flag.

Use `tokensmith_bootstrap_policy_scopes_hint` as the sole configuration path for diagnostic scope hints. This eliminates the legacy fallback and avoids maintaining two names for the same behavior before boot-service is widely adopted.

Update configuration examples and authentication documentation to expose only the canonical input. Add test coverage confirming that the canonical flag remains registered while the legacy flag is unavailable, and document the breaking configuration change in the changelog.

Deployments using a legacy input must migrate to one of:

- `tokensmith_bootstrap_policy_scopes_hint`
- `TOKENSMITH_BOOTSTRAP_POLICY_SCOPES_HINT`
- `--tokensmith-bootstrap-policy-scopes-hint`

Fixes #41 

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update
- [x] Refactor

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
